### PR TITLE
Override content block cells to show id in admin landing page

### DIFF
--- a/app/cells/decidim/admin/content_block/show.erb
+++ b/app/cells/decidim/admin/content_block/show.erb
@@ -1,0 +1,18 @@
+<li draggable="true" data-content-block-id="<%= model.id %>">
+  <div class="draggable-content">
+    <%= name %> <%= "##{model.id}" %>
+    <div>
+      <% if model.persisted? %>
+        <% if has_settings? %>
+          <%= link_to edit_content_block_path, class: "mr-s text-muted" do %>
+            <%= icon "pencil-line", role: "img", "aria-hidden": true %>
+          <% end %>
+        <% end %>
+        <%= link_to content_block_path, method: :delete, data: { confirm: content_block_destroy_confirmation_text }, class: "mr-s text-muted" do %>
+          <%= icon "delete-bin-line", role: "img", "aria-hidden": true %>
+        <% end %>
+      <% end %>
+      <%= icon("draggable", class: "dragger hover:cursor-grab") %>
+    </div>
+  </div>
+</li>

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -7,9 +7,15 @@ require "rails_helper"
 # file should be updated to match any change/bug fix introduced in the core
 checksums = [
   {
+    package: "decidim-admin",
+    files: {
+      "/app/cells/decidim/admin/content_block/show.erb" => "adaab4b21c0d2480d52e15c7098f533e"
+    }
+  },
+  {
     package: "decidim-meetings",
     files: {
-      "/app/controllers/decidim/meetings/meetings_controller.rb" => "da1a19e72fc0692c259671b9fdc8dc8b",
+      "/app/controllers/decidim/meetings/meetings_controller.rb" => "f4adb5da69ac4cb04ac5b5838f7a70fe",
       "/app/commands/decidim/meetings/admin/create_meeting.rb" => "970faa493b3086a0feca886de3b45061",
       "/app/cells/decidim/meetings/dates_and_map_cell.rb" => "7f5aa4ad0f98304dafaf2a719fa146ba",
       "/app/cells/decidim/meetings/dates_and_map/show.erb" => "ae848e2178f6f14f718fea92e75d3635",


### PR DESCRIPTION
Currently, the list of content blocks only show the name that the content block has (i.e. HTML Content Block), but when they are repeated, or there are many, there's no way to know which one is which.

With this PR we add a minimal approach that makes it easier for admins to know which ones they are rearranging, or if it worked, or which ones they want to open.

<img width="2500" height="1136" alt="imatge" src="https://github.com/user-attachments/assets/175f2180-52d4-4eea-aa1a-707c564e681b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a draggable content block item in the admin interface, showing the block name and ID.
  * Included quick actions for editing and deleting content blocks when available.
  * Delete actions now prompt for confirmation before removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->